### PR TITLE
Custom communicator URL

### DIFF
--- a/Model/Service/AcceptCustomer/AbstractRequestHandler.php
+++ b/Model/Service/AcceptCustomer/AbstractRequestHandler.php
@@ -161,7 +161,9 @@ abstract class AbstractRequestHandler
         $gateway = $method->gateway();
 
         // Get CC form token
-        $communicatorUrl = $this->urlBuilder->getUrl('authnetcim/hosted/communicator');
+        $customCommunicatorUrl = $this->method->getConfigData('hosted_custom_communicator_url');
+        $communicatorUrl = $customCommunicatorUrl ?: $this->urlBuilder->getUrl('authnetcim/hosted/communicator');
+
         $gateway->setParameter('hostedProfileIFrameCommunicatorUrl', $communicatorUrl);
         $gateway->setParameter('hostedProfileHeadingBgColor', $method->getConfigData('accent_color'));
         $gateway->setParameter('customerProfileId', $this->getCustomerProfileId());

--- a/Model/Service/AcceptHosted/AbstractRequestHandler.php
+++ b/Model/Service/AcceptHosted/AbstractRequestHandler.php
@@ -144,7 +144,9 @@ abstract class AbstractRequestHandler
         $gateway = $method->gateway();
 
         // Get payment form token
-        $communicatorUrl = $this->urlBuilder->getUrl('authnetcim/hosted/communicator');
+        $customCommunicatorUrl = $this->method->getConfigData('hosted_custom_communicator_url');
+        $communicatorUrl = $customCommunicatorUrl ?: $this->urlBuilder->getUrl('authnetcim/hosted/communicator');
+
         $allowSaveOptIn  = !empty($this->getCustomerId()) ? (bool)$method->getConfigData('allow_unsaved') : false;
         $gateway->setParameter('hostedProfileIFrameCommunicatorUrl', $communicatorUrl);
         $gateway->setParameter('hostedProfileHeadingBgColor', $method->getConfigData('accent_color'));

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -202,6 +202,13 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>Strongly recommended. Do not disable unless you get SSL errors and your host is unable to fix them.</comment>
                 </field>
+                <field id="hosted_custom_communicator_url" translate="label comment" type="text" sortOrder="5050" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Hosted Communicator URL</label>
+                    <comment>If you are using a PWA/headless frontend with Accept Hosted, you must create a page on your frontend domain to pass messages from the form to your checkout. Enter that URL here. Leave blank to use the standard frontend communicator.</comment>
+                    <depends>
+                        <field id="form_type">hosted</field>
+                    </depends>
+                </field>
             </group>
             <group id="authnetcim_ach" translate="label" type="text" sortOrder="33" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Authorize.net CIM - ACH (eCheck)</label>
@@ -373,6 +380,13 @@
                     <label>Verify SSL</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>Strongly recommended. Do not disable unless you get SSL errors and your host is unable to fix them.</comment>
+                </field>
+                <field id="hosted_custom_communicator_url" translate="label comment" type="text" sortOrder="5040" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Hosted Communicator URL</label>
+                    <comment>If you are using a PWA/headless frontend with Accept Hosted, you must create a page on your frontend domain to pass messages from the form to your checkout. Enter that URL here. Leave blank to use the standard frontend communicator.</comment>
+                    <depends>
+                        <field id="form_type">hosted</field>
+                    </depends>
                 </field>
             </group>
         </section>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -39,6 +39,7 @@
                 <enable_webhooks>0</enable_webhooks>
                 <accent_color>#1979C3</accent_color>
                 <enable_hosted_captcha>1</enable_hosted_captcha>
+                <hosted_custom_communicator_url />
                 <client_key />
                 <group>tokenbase</group>
                 <!-- Feature flags -->
@@ -93,6 +94,7 @@
                 <savecard_opt_out>1</savecard_opt_out>
                 <verify_ssl>1</verify_ssl>
                 <enable_webhooks>0</enable_webhooks>
+                <hosted_custom_communicator_url />
                 <group>tokenbase</group>
                 <!-- Feature flags -->
                 <can_order>1</can_order>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message is descriptive of the changes within (see https://keepachangelog.com/en/1.1.0/)
- [x] Code conforms to Magento coding standards
- [x] Code is compatible with all currently supported versions of Magento and PHP


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Running the Accept Hosted payment form on a headless frontend results in inability to complete payment, because the frontend will be on different origin than the communicator (which is loaded from the Magento base URL). The mismatched origin results in all messages failing to pass through to checkout.

Fixes: #1 

## What is the new behavior?

Added settings to configure a custom communicator URL, so that headless implementations can create and set their own communicator page on the frontend origin.

## Does this PR introduce a breaking change?
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

N/A