### PR TITLE
Fixed hosted and webhook transaction amount comparisons

### DIFF
--- a/Gateway/Validator/CreditCard.php
+++ b/Gateway/Validator/CreditCard.php
@@ -165,10 +165,11 @@ class CreditCard extends \ParadoxLabs\TokenBase\Gateway\Validator\CreditCard
         }
 
         $order = $payment->getOrder();
+        $uncoveredAmount = (float)$order->getBaseGrandTotal() - (float)$transactionDetails['amount'];
 
         if ($transactionDetails['customer_email'] !== $order->getCustomerEmail()
             || $transactionDetails['invoice_number'] !== $order->getIncrementId()
-            || $transactionDetails['amount'] < $order->getBaseGrandTotal()) {
+            || $uncoveredAmount > 0.001) {
             throw new \Magento\Framework\Exception\LocalizedException(__('Transaction failed, please try again.'));
         }
 

--- a/Gateway/Validator/NewAch.php
+++ b/Gateway/Validator/NewAch.php
@@ -96,10 +96,11 @@ class NewAch extends \ParadoxLabs\TokenBase\Gateway\Validator\NewAch
         }
 
         $order = $payment->getOrder();
+        $uncoveredAmount = (float)$order->getBaseGrandTotal() - (float)$transactionDetails['amount'];
 
         if ($transactionDetails['customer_email'] !== $order->getCustomerEmail()
             || $transactionDetails['invoice_number'] !== $order->getIncrementId()
-            || $transactionDetails['amount'] < $order->getBaseGrandTotal()) {
+            || $uncoveredAmount > 0.001) {
             throw new LocalizedException(__('Transaction failed, please try again.'));
         }
 

--- a/Model/Service/WebhookProcessor.php
+++ b/Model/Service/WebhookProcessor.php
@@ -406,7 +406,8 @@ class WebhookProcessor
 
         // Note: Invoices don't have a way to specify an amount independent of items/totals calculation. Could
         // theoretically calculate it ourselves, but not flawlessly. So: Full captures only.
-        if ($txnDetails['amount_settled'] < $order->getTotalDue()) {
+        $uncoveredAmount = (float)$order->getTotalDue() - (float)$txnDetails['amount_settled'];
+        if ($uncoveredAmount > 0.001) {
             $this->helper->log(
                 $this->configProvider->getCode(),
                 sprintf(

--- a/Observer/PaymentMethodAssignDataObserver.php
+++ b/Observer/PaymentMethodAssignDataObserver.php
@@ -201,9 +201,10 @@ class PaymentMethodAssignDataObserver extends \ParadoxLabs\TokenBase\Observer\Pa
         }
 
         $quote = $payment->getQuote();
+        $uncoveredAmount = (float)$quote->getBaseGrandTotal() - (float)$transactionDetails->getData('amount');
         if ($transactionDetails->getData('customer_email') !== $quote->getBillingAddress()->getEmail()
             || $transactionDetails->getData('invoice_number') !== (string)$quote->getReservedOrderId()
-            || $transactionDetails->getData('amount') < $quote->getBaseGrandTotal()) {
+            || $uncoveredAmount > 0.001) {
             throw new \Magento\Framework\Exception\LocalizedException(__('Transaction failed, please try again.'));
         }
 


### PR DESCRIPTION
... to handle string versus float values and precision. (#18)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message is descriptive of the changes within (see https://keepachangelog.com/en/1.1.0/)
- [x] Code conforms to Magento coding standards
- [x] Code is compatible with all currently supported versions of Magento and PHP


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #18

Transaction value comparisons are loosely typed, and can cause mistaken errors if one of the types is string and the other is float. It may also fail if float precision varies slightly.


## What is the new behavior?

For each value check, the code now converts both values to float, and then checks if the difference is meaningful (greater than 0.001, a tenth of a cent in most currencies). If the transaction amount leaves more than that amount of the order uncovered/unpaid, that's a valid error case.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information